### PR TITLE
Feedback on conditional sensor_msgs_library target

### DIFF
--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -73,6 +73,12 @@ if(TARGET ${cpp_target})
   install(
     TARGETS ${PROJECT_NAME}_library EXPORT export_${PROJECT_NAME}
   )
+
+  # Export old-style CMake variables
+  ament_export_include_directories("include/${PROJECT_NAME}")
+
+  # Export modern CMake targets
+  ament_export_targets(export_${PROJECT_NAME})
 endif()
 
 if(BUILD_TESTING)
@@ -88,12 +94,6 @@ if(BUILD_TESTING)
   rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
   target_link_libraries(test_sensor_msgs "${cpp_typesupport_target}")
 endif()
-
-# Export old-style CMake variables
-ament_export_include_directories("include/${PROJECT_NAME}")
-
-# Export modern CMake targets
-ament_export_targets(export_${PROJECT_NAME})
 
 ament_export_dependencies(rosidl_default_runtime)
 

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -55,21 +55,25 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-rosidl_get_typesupport_target(cpp_target "${PROJECT_NAME}" "rosidl_generator_cpp")
+set(cpp_target
+  "${PROJECT_NAME}__rosidl_generator_cpp"
+)
 
-add_library(${PROJECT_NAME}_library INTERFACE)
-target_include_directories(${PROJECT_NAME}_library INTERFACE
+if(TARGET ${cpp_target})
+  add_library(${PROJECT_NAME}_library INTERFACE)
+  target_include_directories(${PROJECT_NAME}_library INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-target_link_libraries(${PROJECT_NAME}_library INTERFACE
+  target_link_libraries(${PROJECT_NAME}_library INTERFACE
   "${cpp_target}")
 
-install(DIRECTORY include/
-  DESTINATION include/${PROJECT_NAME}
-)
-install(
-  TARGETS ${PROJECT_NAME}_library EXPORT export_${PROJECT_NAME}
-)
+  install(DIRECTORY include/
+    DESTINATION include/${PROJECT_NAME}
+  )
+  install(
+    TARGETS ${PROJECT_NAME}_library EXPORT export_${PROJECT_NAME}
+  )
+endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)

--- a/sensor_msgs/CMakeLists.txt
+++ b/sensor_msgs/CMakeLists.txt
@@ -55,17 +55,15 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   ADD_LINTER_TESTS
 )
 
-set(cpp_target
-  "${PROJECT_NAME}__rosidl_generator_cpp"
-)
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 
-if(TARGET ${cpp_target})
+if(cpp_typesupport_target)
   add_library(${PROJECT_NAME}_library INTERFACE)
   target_include_directories(${PROJECT_NAME}_library INTERFACE
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
   target_link_libraries(${PROJECT_NAME}_library INTERFACE
-  "${cpp_target}")
+  "${cpp_typesupport_target}")
 
   install(DIRECTORY include/
     DESTINATION include/${PROJECT_NAME}
@@ -79,20 +77,20 @@ if(TARGET ${cpp_target})
 
   # Export modern CMake targets
   ament_export_targets(export_${PROJECT_NAME})
+
+  if(BUILD_TESTING)
+    ament_add_gtest(test_sensor_msgs
+      test/test_image_encodings.cpp
+      test/test_pointcloud_conversion.cpp
+      test/test_pointcloud_iterator.cpp)
+    target_link_libraries(test_sensor_msgs ${PROJECT_NAME}_library)
+  endif()
 endif()
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-
-  include_directories(include)
-  ament_add_gtest(test_sensor_msgs
-    test/test_image_encodings.cpp
-    test/test_pointcloud_conversion.cpp
-    test/test_pointcloud_iterator.cpp)
-  rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
-  target_link_libraries(test_sensor_msgs "${cpp_typesupport_target}")
 endif()
 
 ament_export_dependencies(rosidl_default_runtime)


### PR DESCRIPTION
PR with feedback for https://github.com/ros2/common_interfaces/pull/183

* Uses https://github.com/ros2/rosidl/pull/672
* Conditionally test the `sensor_msgs_library` target too
* Use the `rosidl_typesupport_cpp` target instead of the `rosidl_generator_cpp` target so downstream users will link against the the typesupport library and transitively get the `rosidl_generator_cpp` include paths too

